### PR TITLE
モバイルサイドバーの改善：data-controller属性の見直し＋軽微な修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,26 +26,22 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body class="bg-gray-100 min-h-screen flex flex-col">
+  <body class="bg-gray-100 min-h-screen flex flex-col" data-controller="sidebar">
   <% if @current_teacher %>
-    <!-- ヘッダー -->
     <header>
       <%= render 'shared/header' %>
     </header>
 
     <div class="flex flex-1 min-h-0">
-      <!-- サイドバー -->
       <aside class="hidden md:block w-64 bg-white shadow h-full">
         <%= render 'shared/sidebar' %>
       </aside>
 
-      <!-- モバイル用サイドバー -->
       <div data-sidebar-target="menu"
            class="fixed inset-y-0 left-0 z-50 w-64 bg-white shadow transform -translate-x-full transition-transform md:hidden">
         <%= render 'shared/sidebar' %>
       </div>
 
-      <!-- メイン -->
       <main class="flex-1 overflow-y-auto p-6">
         <% flash.each do |type, message| %>
           <% color = case type.to_sym
@@ -62,7 +58,6 @@
       </main>
     </div>
   <% else %>
-    <!-- 未ログイン時 -->
     <main class="flex-1 p-6">
       <% flash.each do |type, message| %>
         <% color = case type.to_sym

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,7 @@
 <div class="h-16 flex items-center justify-between bg-blue-600 text-white px-4 py-3" data-controller="dropdown">
   <button
       class="md:hidden mr-4 text-white focus:outline-none"
-      data-action="click->dropdown#toggleMenu"
+      data-action="click->sidebar#toggle"
     >
       ☰
     </button>


### PR DESCRIPTION
### 概要
モバイル表示時のサイドバー挙動に関する軽微な修正です。

### 主な変更点
- `data-controller="sidebar"` の記述を適切な位置へ移動
- レスポンシブ表示時に意図せず表示が崩れる問題を修正

### 備考
Tailwind CSS + Stimulus を併用した構成のため、今後もコンポーネントごとにControllerを整理する予定です。