### PR TITLE
fix: Stimulusサイドバー開閉処理とTurbo対応を追加

### DIFF
--- a/app/javascript/controllers/sidebar_controller.js
+++ b/app/javascript/controllers/sidebar_controller.js
@@ -4,7 +4,19 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["menu"]
 
+  connect() {
+    document.addEventListener("turbo:before-visit", () => {
+      this.close()
+    })
+  }
+
   toggle() {
     this.menuTarget.classList.toggle("-translate-x-full")
+  }
+
+  close() {
+    if (this.hasMenuTarget) {
+    this.menuTarget.classList.add("-translate-x-full")
+    }
   }
 }

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,22 +1,27 @@
-  <h2 class="text-lg font-bold mb-4">メニュー</h2>
-  <ul>
-    <li class="mb-2">
-      <a href="<%= students_path %>"
-         class="<%= current_page?(students_path) ? 'text-blue-700 font-semibold' : 'text-blue-500 hover:underline' %>">
-        生徒一覧
-      </a>
-    </li>
-    <li class="mb-2">
-      <a href="<%= skills_path %>"
-         class="<%= current_page?(skills_path) ? 'text-blue-700 font-semibold' : 'text-blue-500 hover:underline' %>">
-        特技タグ
-      </a>
-    </li>
-    <li class="mb-2">
-      <a href="<%= group_assignments_path %>"
-         class="<%= current_page?(group_assignments_path) ? 'text-blue-700 font-semibold' : 'text-blue-500 hover:underline' %>">
-        グループ分け
-      </a>
-    </li>
-  </ul>
-</aside>
+<h2 class="text-lg font-bold mb-4">メニュー</h2>
+
+<!-- モバイル用 ✕ボタン -->
+<button data-action="click->sidebar#toggle" class="md:hidden text-gray-500 absolute top-4 right-4">
+  ✕
+</button>
+
+<ul>
+  <li class="mb-2">
+    <a href="<%= students_path %>"
+       class="<%= current_page?(students_path) ? 'text-blue-700 font-semibold' : 'text-blue-500 hover:underline' %>">
+      生徒一覧
+    </a>
+  </li>
+  <li class="mb-2">
+    <a href="<%= skills_path %>"
+       class="<%= current_page?(skills_path) ? 'text-blue-700 font-semibold' : 'text-blue-500 hover:underline' %>">
+      特技タグ
+    </a>
+  </li>
+  <li class="mb-2">
+    <a href="<%= group_assignments_path %>"
+       class="<%= current_page?(group_assignments_path) ? 'text-blue-700 font-semibold' : 'text-blue-500 hover:underline' %>">
+      グループ分け
+    </a>
+  </li>
+</ul>


### PR DESCRIPTION
- sidebar_controller.js に Turbo対応の close処理を実装

- Xボタンによる開閉を可能に

- Stimulusの menu target 不在時のエラーは未対処（今後考慮）