### PR TITLE
UI/grouping form refine　グループ分け時の特技、生徒の欄を個別でスクロール化

### DIFF
--- a/app/views/group_assignments/_form.html.erb
+++ b/app/views/group_assignments/_form.html.erb
@@ -30,31 +30,31 @@
     </div>
 
     <div class="mb-4" data-controller="filter select-all">
-  <label class="block font-bold mb-1">生徒検索</label>
-  <%= text_field_tag :student_search, nil,
-        class: "border rounded w-full p-2 mb-2",
-        data: { filter_target: "input", action: "input->filter#search" } %>
+    <label class="block font-bold mb-1">生徒検索</label>
+    <%= text_field_tag :student_search, nil,
+          class: "border rounded w-full p-2 mb-2",
+          data: { filter_target: "input", action: "input->filter#search" } %>
 
-  <div class="mb-2">
-    <label>
-      <input type="checkbox" data-select-all-target="source" data-action="select-all#toggleAll">
-      全員選択
-    </label>
-  </div>
-
-  <div class="h-64 overflow-y-scroll border rounded p-2 bg-gray-50">
-    <% students.each do |student| %>
-      <label class="block" data-filter-target="item">
-        <%= check_box_tag "group_assignment[student_ids][]",
-                          student.id,
-                          group_assignment.student_ids&.include?(student.id),
-                          class: "mr-2",
-                          data: { select_all_target: "checkbox" } %>
-        <%= student.name %>
+    <div class="mb-2">
+      <label>
+        <input type="checkbox" data-select-all-target="source" data-action="select-all#toggleAll">
+        全員選択
       </label>
-    <% end %>
+    </div>
+
+    <div class="h-64 overflow-y-scroll border rounded p-2 bg-gray-50">
+      <% students.each do |student| %>
+        <label class="block" data-filter-target="item">
+          <%= check_box_tag "group_assignment[student_ids][]",
+                            student.id,
+                            group_assignment.student_ids&.include?(student.id),
+                            class: "mr-2",
+                            data: { select_all_target: "checkbox" } %>
+          <%= student.name %>
+        </label>
+      <% end %>
+    </div>
   </div>
-</div>
 
     <div class="mb-4">
   <p class="font-bold mb-2">能力を選択（重みを設定）</p>
@@ -81,15 +81,16 @@
   </div>
 
   <div class="mb-4" data-controller="filter">
-      <p class="font-bold mb-2">特技を基準にばらけさせる（1つだけ）</p>
+    <p class="font-bold mb-2">特技を基準にばらけさせる（1つだけ）</p>
 
-      <%= label_tag :skill_search, "特技検索", class: "block font-bold mb-1" %>
-      <%= text_field_tag :skill_search, nil,
-            class: "border rounded w-full p-2 mb-2",
-            data: { filter_target: "input", action: "input->filter#search" } %>
+    <%= label_tag :skill_search, "特技検索", class: "block font-bold mb-1" %>
+    <%= text_field_tag :skill_search, nil,
+          class: "border rounded w-full p-2 mb-2",
+          data: { filter_target: "input", action: "input->filter#search" } %>
 
+    <div class="h-64 overflow-y-scroll border rounded p-2 bg-gray-50">
       <label class="block" data-filter-target="item">
-        <%= radio_button_tag "group_assignment[skill_ids][]", "", group_assignment.skill_ids.blank?, class: 'mr-2' %>
+       <%= radio_button_tag "group_assignment[skill_ids][]", "", group_assignment.skill_ids.blank?, class: 'mr-2' %>
         なし（特技を考慮しない）
       </label>
 
@@ -100,6 +101,7 @@
         </label>
       <% end %>
     </div>
+  </div>
 
     <%= form.submit group_assignment.new_record? ? '作成' : '更新',
           class: 'bg-blue-500 text-white font-bold py-2 px-4 rounded' %>


### PR DESCRIPTION
🛠 概要（What）
グループ分け作成フォームにおいて、
生徒選択欄と特技選択欄が増えてくると操作性が悪くなる問題を改善しました。

🔧 変更点（Changes）
生徒選択欄：

検索ボックスを追加（名前で絞り込み可能）

生徒一覧にスクロールを追加（overflow制御）

特技選択欄：

ラジオボタン一覧に検索機能を追加

多数の特技がある場合でも見やすく

📱 目的（Why）
生徒数・特技数が多い環境でも、
フォームの視認性・操作性を保つためのUI改善です。

