### PR TITLE
refactor: SkillsControllerのFat化を解消するためSkillFormを導入

### DIFF
--- a/app/controllers/skills_controller.rb
+++ b/app/controllers/skills_controller.rb
@@ -1,56 +1,42 @@
 class SkillsController < ApplicationController
   before_action :authenticate_teacher!
-  before_action :set_skill, only: [ :show, :edit, :update, :destroy ]
+  before_action :set_skill, only: %i[edit update destroy]
 
   def index
-    @skills = current_teacher.skills
-    @skills = @skills.where("name ILIKE ?", "%#{params[:q]}%") if params[:q].present?
-
-    case params[:sort]
-    when "name"
-      @skills = @skills.order(:name)
-    when "created_at_desc"
-      @skills = @skills.order(created_at: :desc)
-    when "created_at_asc"
-      @skills = @skills.order(created_at: :asc)
-    end
-
-    @skills = @skills.page(params[:page]).per(12)
+    permitted = params.permit(:q, :sort, :page)
+    @skills = SkillQuery.new(current_teacher.skills, permitted).call
   end
 
   def autocomplete
-    names = current_teacher.skills.where("name ILIKE ?", "%#{params[:q]}%").limit(10).pluck(:name)
+    names = current_teacher.skills
+                           .where("name ILIKE ?", "%#{params[:q]}%")
+                           .limit(10)
+                           .pluck(:name)
     render json: names
   end
 
   def new
-    @skill = Skill.new
-    @students = current_teacher.students
+    @form = SkillForm.new(teacher: current_teacher)
   end
 
   def create
-    @skill = current_teacher.skills.build(skill_params)
-    if @skill.save
-      @skill.student_ids = params[:skill][:student_ids] if params[:skill][:student_ids].present?
+    @form = SkillForm.new(skill_form_params, teacher: current_teacher)
+    if @form.save
       redirect_to skills_path, notice: "特技が作成されました！"
     else
-      @students = current_teacher.students
       render :new
     end
   end
 
-  def show
-  end
-
   def edit
-    @students = current_teacher.students
+    @form = SkillForm.new(skill: @skill, teacher: current_teacher)
   end
 
   def update
-    if @skill.update(skill_params)
+    @form = SkillForm.new(skill_form_params, skill: @skill, teacher: current_teacher)
+    if @form.update
       redirect_to skills_path, notice: "特技が更新されました！"
     else
-      @students = current_teacher.students
       render :edit
     end
   end
@@ -64,12 +50,10 @@ class SkillsController < ApplicationController
 
   def set_skill
     @skill = current_teacher.skills.find_by(id: params[:id])
-    unless @skill
-      redirect_to skills_path, alert: "特技が見つかりません"
-    end
+    redirect_to skills_path, alert: "特技が見つかりません" unless @skill
   end
 
-  def skill_params
-    params.require(:skill).permit(:name, student_ids: [])
+  def skill_form_params
+    params.require(:skill_form).permit(:name, student_ids: [])
   end
 end

--- a/app/forms/skill_form.rb
+++ b/app/forms/skill_form.rb
@@ -1,0 +1,39 @@
+class SkillForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_reader :skill, :teacher
+
+  attribute :name, :string
+  attribute :student_ids, default: []
+
+  validates :name, presence: true
+
+  def initialize(attributes = {}, skill: nil, teacher:)
+    @teacher = teacher
+    @skill = skill || teacher.skills.build
+    attributes = default_attributes if attributes.blank?
+    super(attributes)
+  end
+
+  def save
+    return false unless valid?
+
+    skill.name = name
+    skill.student_ids = student_ids.reject(&:blank?)
+    skill.save
+  end
+
+  def update
+    save
+  end
+
+  private
+
+  def default_attributes
+    {
+      name: skill.name,
+      student_ids: skill.student_ids
+    }
+  end
+end

--- a/app/queries/skill_query.rb
+++ b/app/queries/skill_query.rb
@@ -1,0 +1,22 @@
+class SkillQuery
+  def initialize(relation, params)
+    @relation = relation
+    @params = params
+  end
+
+  def call
+    skills = @relation
+    skills = skills.where("name ILIKE ?", "%#{@params[:q]}%") if @params[:q].present?
+
+    case @params[:sort]
+    when "name"
+      skills = skills.order(:name)
+    when "created_at_desc"
+      skills = skills.order(created_at: :desc)
+    when "created_at_asc"
+      skills = skills.order(created_at: :asc)
+    end
+
+    skills.page(@params[:page]).per(12)
+  end
+end

--- a/app/views/skills/_form.html.erb
+++ b/app/views/skills/_form.html.erb
@@ -1,10 +1,20 @@
 <div class="max-w-xl mx-auto p-6 bg-white shadow-md rounded-md">
-  <%= form_with(model: skill, local: true, data: { turbo: false }) do |form| %>
-    <% if skill.errors.any? %>
-      <div class="bg-red-100 text-red-700 p-3 mb-4 rounded">
-        <p><%= pluralize(skill.errors.count, "エラー") %>があります:</p>
-        <ul>
-          <% skill.errors.full_messages.each do |msg| %>
+  <%= form_with(
+      model: form,
+      scope: :skill_form,
+      url: form.skill.new_record? ? skills_path : skill_path(form.skill),
+      method: form.skill.new_record? ? :post : :patch,
+      local: true,
+      data: { turbo: false }
+    ) do |f| %>
+
+    <% if form.errors.any? %>
+      <div class="bg-red-100 text-red-700 p-3 mb-4 rounded border border-red-500">
+        <p class="font-bold">
+          <%= pluralize(form.errors.count, "エラー") %>があります:
+        </p>
+        <ul class="list-disc list-inside">
+          <% form.errors.full_messages.each do |msg| %>
             <li><%= msg %></li>
           <% end %>
         </ul>
@@ -12,8 +22,9 @@
     <% end %>
 
     <div class="mb-4">
-      <%= form.label :name, '特技名', class: 'block font-bold mb-1' %>
-      <%= form.text_field :name, class: 'border rounded w-full p-2' %>
+      <%= f.label :name, '特技名', class: 'block font-bold mb-1' %>
+      <%= f.text_field :name,
+            class: "border rounded w-full p-2 #{'border-red-500' if form.errors[:name].any?}" %>
     </div>
 
     <div class="mb-4" data-controller="filter">
@@ -23,15 +34,22 @@
             data: { filter_target: "input", action: "input->filter#search" } %>
 
       <p class="font-bold mb-2">対象生徒を選択</p>
-      <% students.each do |student| %>
+      <% form.teacher.students.each do |student| %>
         <label class="block" data-filter-target="item">
-          <%= check_box_tag "skill[student_ids][]", student.id, skill.student_ids.include?(student.id), class: 'mr-2' %>
+          <%= check_box_tag "skill_form[student_ids][]", student.id,
+                form.student_ids.include?(student.id),
+                class: 'mr-2' %>
           <%= student.name %>
         </label>
       <% end %>
     </div>
 
-    <%= form.submit skill.new_record? ? '追加' : '更新', class: 'bg-blue-500 text-white font-bold py-2 px-4 rounded' %>
-    <%= link_to '特技一覧に戻る', skills_path, class: "bg-blue-500 text-white font-bold px-6 py-2 rounded" %>
+    <div class="flex justify-between mt-6">
+      <%= f.submit form.skill.new_record? ? '作成' : '更新',
+            class: 'bg-blue-500 text-white font-bold py-2 px-4 rounded' %>
+      <%= link_to '特技一覧に戻る', skills_path,
+            class: "bg-gray-300 text-gray-800 font-bold px-6 py-2 rounded" %>
+    </div>
+
   <% end %>
 </div>

--- a/app/views/skills/edit.html.erb
+++ b/app/views/skills/edit.html.erb
@@ -1,5 +1,5 @@
 <h1 class="text-2xl font-bold mb-6 text-center">
-  <%= @skill.new_record? ? '特技を追加' : '特技を編集' %>
+  <%= @form.skill.new_record? ? '特技を追加' : '特技を編集' %>
 </h1>
 
-<%= render 'form', skill: @skill, students: @students %>
+<%= render 'form', form: @form %>

--- a/app/views/skills/new.html.erb
+++ b/app/views/skills/new.html.erb
@@ -1,5 +1,5 @@
 <h1 class="text-2xl font-bold mb-6 text-center">
-  <%= @skill.new_record? ? '特技を追加' : '特技を編集' %>
+  <%= @form.skill.new_record? ? '特技を追加' : '特技を編集' %>
 </h1>
 
-<%= render 'form', skill: @skill, students: @students %>
+<%= render 'form', form: @form %>


### PR DESCRIPTION
- 複数モデル（Skill + Student）の同時保存処理をFormオブジェクトに移管
- new/createアクションの可読性向上